### PR TITLE
Use compact Json representation

### DIFF
--- a/codeql_postproc/helpers/sarif.py
+++ b/codeql_postproc/helpers/sarif.py
@@ -42,5 +42,5 @@ class Sarif:
         except jsonschema.exceptions.ValidationError as e:
             raise InvalidSarif(f"Adding the version control provenance information results in an invalid Sarif file because {e.message}!")
         with self.path.open(mode="w") as fd:
-            json.dump(self.content, fd, indent=2)
+            json.dump(self.content, fd)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codeql-postproc"
-version = "0.2.0"
+version = "0.2.1"
 description = "A post processing tool for CodeQL databases and Sarif result files."
 authors = ["Remco Vermeulen <rvermeulen@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
To reduce the size of the final Sarif file we use the most compact representation.